### PR TITLE
Removes built-in browser hotkey highjacking

### DIFF
--- a/index.html
+++ b/index.html
@@ -57,7 +57,7 @@
 
     window.addEventListener("keydown", function (e) {
       var search = document.querySelector('input[type="search"]')
-      if (search && e.which == 70 && (e.ctrlKey || e.metaKey)) {
+      if (search && e.code === 'KeyK' && (e.ctrlKey || e.metaKey)) {
         e.preventDefault()
         search.focus()
       }


### PR DESCRIPTION
Using `cmd + f` or `ctrl + f` to search on a page is highjacked, and you're routed to the documentation search. This makes searching for something on the page you're currently on a painful experience. This changes the key from `f` to `k`. Which is an adopted standard for documentation pages, as can be seen on e.g https://vuejs.org/ and https://tailwindcss.com/. It also refactors the key detection method away from the now deprecated UIEvent.which property.